### PR TITLE
Copy edits and tone standardization

### DIFF
--- a/_pages/mission.md
+++ b/_pages/mission.md
@@ -9,14 +9,14 @@ deck: 'Accelerate IT modernization to improve the citizen experience, improve ou
 
 ## Our Values:
 
-* **Know our customer** - Understanding and anticipating the needs of our customer is our highest priority. Speaking with our customers and regularly gathering their insights allows agencies to rethink the way they deliver technology solutions today.
+* **Know our customer.** Understanding and anticipating the needs of our customers is our highest priority. Speaking with our customers and regularly gathering their insights allows agencies to rethink the way they deliver technology solutions today.
 
-* **Innovate from within** - There is a lot of great technical talent across the government, we strive to identify those innovators and harness their experience in the  Centers of Excellence (CoEs).
+* **Innovate from within.** Technical talent exists across government. We strive to identify innovators and harness their experiences.
 
-* **Collaborate for success** - The CoEs recruit the best and brightest from our customer’s workforce to co-lead modernization efforts and ensure success and longevity beyond CoE engagements.
+* **Collaborate for success.** We recruit the best and brightest from our customers' workforces to co-lead modernization efforts and ensure success and longevity beyond CoE engagements.
 
-* **Rely on best practices** - We also partner with the private sector to implement the latest technology, utilize commercial practices, accelerate modernization and avoid common pitfalls.
+* **Rely on best practices.** We also partner with the private sector to implement the latest technology, utilize commercial practices, accelerate modernization and avoid common pitfalls.
 
-* **Centralize our resources** - By standing up the CoEs we strive to centralize and share the brightest talent, proven processes and acquisition vehicles to yield the best results across government.
+* **Centralize our resources.** We strive to centralize and share the brightest talent, proven processes and acquisition vehicles to yield the best results across government.
 
 {% include image-wide.html path="/team/team.jpeg" alt-text="The COE team" caption="The CoE Team and USDA Partners" %}


### PR DESCRIPTION
- eliminated the dashes, we don't need 'em because the headlines are full sentences and can stand alone
- did some copy editing
- took out extraneous uses of "CoEs" in favor of "we"