### PR TITLE
Putting the Edit button back in

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -52,7 +52,7 @@ body{
     border-radius: 3px;
     font-size: 16px;
     font-weight: bold;
-    display: none;
+    display: inline-block;
   }
   .button-edit:hover{
     background: rgb(202, 222, 235);


### PR DESCRIPTION
Somehow this got removed.
Adding it back in.

Preview: https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/edit-button/