### PR TITLE
Remove un-needed slash

### DIFF
--- a/_posts/2018-08-17-cx-update-5.md
+++ b/_posts/2018-08-17-cx-update-5.md
@@ -23,23 +23,23 @@ Among the 13 key findings, the following were identified as the most impactful:
     <hr>
     
     {% include download_pdf.html download_title="Research Findings and Recommendations (PDF, 3 MB)"
-    download_url="/docs/Findings-Volume-1-Farm-Loans-Final-Report.pdf" %}
+    download_url="docs/Findings-Volume-1-Farm-Loans-Final-Report.pdf" %}
     What we learned over the course of four workshops and visits to six different regions
 
     <hr>
 
     {% include download_pdf.html download_title="Methodology (PDF, 14 MB)" 
-    download_url="/docs/Methodology-Volume-2-Farm-Loans-Final-Report.pdf" %}
+    download_url="docs/Methodology-Volume-2-Farm-Loans-Final-Report.pdf" %}
     How the research and related activities were accomplished
 
     <hr>
 
 
-    {% include download_pdf.html download_title="Stories (PDF, 4 MB)" download_url="/docs/Stories-Volume-3-Farm-Loans-Final-Report.pdf" %}
+    {% include download_pdf.html download_title="Stories (PDF, 4 MB)" download_url="docs/Stories-Volume-3-Farm-Loans-Final-Report.pdf" %}
     Fictional stories derived from field visits that are composites of real producers and Loan Officers
 
     <hr>
 
-    {% include download_pdf.html download_title="Farm Loans Final Report Briefing (PDF, 13.5 MB)" download_url="/docs/Farm-Loans-Final-Report-Briefing.pdf" %}
+    {% include download_pdf.html download_title="Farm Loans Final Report Briefing (PDF, 13.5 MB)" download_url="docs/Farm-Loans-Final-Report-Briefing.pdf" %}
     An executive summary of the findings
 </div>


### PR DESCRIPTION
The helper automatically adds slash to url. Removing the additional slash fixes broken urls.