### PR TITLE
Adds jekyll sitemap plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "minima", "~> 2.0"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem 'jekyll-redirect-from'
+  gem 'jekyll-sitemap'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.5.0)
       jekyll (~> 3.3)
+    jekyll-sitemap (1.3.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.1.2)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -70,8 +72,9 @@ DEPENDENCIES
   jekyll (~> 3.8.4)
   jekyll-feed (~> 0.6)
   jekyll-redirect-from
+  jekyll-sitemap
   minima (~> 2.0)
   tzinfo-data
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,14 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+  # If all gem plugins have the same priority, they will be executed in the order
+  # they are required, generally. Thus, if you have other plugins which generate
+  # content and store that content in site.pages, site.posts, or site.collections,
+  # be sure to require jekyll-sitemap either after those other gems if you want
+  # the sitemap to include the generated content, or before those other gems if
+  # you don't want the sitemap to include the generated content from the gems. 
+  #                                 see: https://github.com/jekyll/jekyll-sitemap
+  - jekyll-sitemap
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds jekyll-sitemap plugin to automatically generate a sitemaps.org compatible sitemap

~[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)~
