### PR TITLE
Only use post excerpts

### DIFF
--- a/coe/cloud-adoption.html
+++ b/coe/cloud-adoption.html
@@ -51,7 +51,8 @@ layout: default
             <div class="article-head">
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
-                {{ post.content }}
+                {{ post.excerpt }}
+                <p><a href="{{post.url}}">Read more »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/cloud-adoption.html
+++ b/coe/cloud-adoption.html
@@ -52,7 +52,7 @@ layout: default
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
                 {{ post.excerpt }}
-                <p><a href="{{post.url}}">Read more »</a></p>
+                <p><a href="{{post.url}}">Continue to read the full article »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/contact-center.html
+++ b/coe/contact-center.html
@@ -36,7 +36,8 @@ initiative: Contact Center
             <div class="article-head">
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
-                {{ post.content }}
+                {{ post.excerpt }}
+                <p><a href="{{post.url}}">Read more »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/contact-center.html
+++ b/coe/contact-center.html
@@ -37,7 +37,7 @@ initiative: Contact Center
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
                 {{ post.excerpt }}
-                <p><a href="{{post.url}}">Read more »</a></p>
+                <p><a href="{{post.url}}">Continue to read the full article »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/customer-experience.html
+++ b/coe/customer-experience.html
@@ -31,7 +31,8 @@ their customers and their needs, and helps translate those findings into actions
             <div class="article-head">
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
-                {{ post.content }}
+                {{ post.excerpt }}
+                <p><a href="{{post.url}}">Read more »</a></p>
 	    </div>
 	{% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/customer-experience.html
+++ b/coe/customer-experience.html
@@ -32,7 +32,7 @@ their customers and their needs, and helps translate those findings into actions
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
                 {{ post.excerpt }}
-                <p><a href="{{post.url}}">Read more »</a></p>
+                <p><a href="{{post.url}}">Continue to read the full article »</a></p>
 	    </div>
 	{% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/data-analytics.html
+++ b/coe/data-analytics.html
@@ -42,7 +42,8 @@ layout: default
             <div class="article-head">
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
-                {{ post.content }}
+                {{ post.excerpt }}
+                <p><a href="{{post.url}}">Read more »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/data-analytics.html
+++ b/coe/data-analytics.html
@@ -43,7 +43,7 @@ layout: default
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
                 {{ post.excerpt }}
-                <p><a href="{{post.url}}">Read more »</a></p>
+                <p><a href="{{post.url}}">Continue to read the full article »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/infrastructure-optimization.html
+++ b/coe/infrastructure-optimization.html
@@ -43,7 +43,8 @@ coe: Infrastructure Optimization
             <div class="article-head">
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
-                {{ post.content }}
+                {{ post.excerpt }}
+                <p><a href="{{post.url}}">Read more »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->

--- a/coe/infrastructure-optimization.html
+++ b/coe/infrastructure-optimization.html
@@ -44,7 +44,7 @@ coe: Infrastructure Optimization
                 <em class="date">{{ post.date | date: '%B %d, %Y' }}</em>
                 <h3 class="title"><a href="{{site.baseurl}}{{post.url}}">{{post.title}}</a></h3>
                 {{ post.excerpt }}
-                <p><a href="{{post.url}}">Read more »</a></p>
+                <p><a href="{{post.url}}">Continue to read the full article »</a></p>
             </div>
         {% endfor %}
     </div> <!-- /.usa-width-two-thirds -->


### PR DESCRIPTION
Closes #131. 
Changes proposed in this pull request:
- use first paragraph of each post as its excerpt, with a "read more" link, rather than showing the whole post on each center homepage.

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/hjb/show-post-excerpts/)
