### PR TITLE
Add docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+jekyll:
+    image: jekyll/jekyll
+    command: jekyll serve --watch --incremental
+    ports:
+        - 4000:4000
+    volumes:
+        - .:/srv/jekyll


### PR DESCRIPTION
To make it easier to run this project locally, use Docker.

Changes proposed in this pull request (no visible changes):
- Adds a `docker-compose.yml` file with a Jekyll image

[:sunglasses: PREVIEW](/https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/BRANCH_NAME/)
