### PR TITLE
Set published: false flags on pages that shouldn't be live

### DIFF
--- a/coe/centers-of-excellence.html
+++ b/coe/centers-of-excellence.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+published: false
 ---
 
 <section class="usa-grid usa-section">

--- a/coe/playbooks/ca-playbook.html
+++ b/coe/playbooks/ca-playbook.html
@@ -1,3 +1,7 @@
+---
+layout: default
+published: false
+---
 <!doctype html>
 <html lang="en">
 <head>

--- a/coe/playbooks/cc-playbook.html
+++ b/coe/playbooks/cc-playbook.html
@@ -1,3 +1,7 @@
+---
+layout: default
+published: false
+---
 <!doctype html>
 <html lang="en">
 <head>

--- a/coe/playbooks/cx-playbook.html
+++ b/coe/playbooks/cx-playbook.html
@@ -1,3 +1,7 @@
+---
+layout: default
+published: false
+---
 <!doctype html>
 <html lang="en">
 <head>

--- a/coe/playbooks/da-playbook.html
+++ b/coe/playbooks/da-playbook.html
@@ -1,3 +1,7 @@
+---
+layout: default
+published: false
+---
 <!doctype html>
 <html lang="en">
 <head>

--- a/coe/playbooks/io-playbook.html
+++ b/coe/playbooks/io-playbook.html
@@ -1,3 +1,7 @@
+---
+layout: default
+published: false
+---
 <!doctype html>
 <html lang="en">
 <head>


### PR DESCRIPTION
Several pages that should have been removed were still being served. In order to preserve the content while not serving the pages to search engines, add the following to those pages:
```
---
published: false
---
```

Changes proposed in this pull request:
- Sets `published: false` in front matter of pages that shouldn't be live
