### PR TITLE
Unpublish USDA page and update nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -162,13 +162,7 @@
                     </ul>
                 </li>
                 <li>
-                    <button id="nav-work" class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="extended-nav-section-five">
-                      <span>Our Work</span>
-                    </button>
-                    <ul id="extended-nav-section-five" class="usa-nav-submenu">
-                        <li><a href="{{site.baseurl}}/work/usda.html">USDA</a></li>
-
-                    </ul>
+                  <a class="usa-nav-link" href="{{site.baseurl}}/press/updates.html">Latest Updates</a>
                 </li>
                 <li>
                     <button id="nav-press" class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="extended-nav-section-three">

--- a/work/usda.html
+++ b/work/usda.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+published: false
 ---
 
 <section class="usa-grid usa-section">


### PR DESCRIPTION
Changes proposed in this pull request:
- Set USDA frontmatter to `published: false` to prevent it from being publicly accessible
- Update nav to have "Latest Updates" instead

[:sunglasses: PREVIEW](/https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/hjb/remove-usda-page/)
