### PR TITLE
Fix artificial intelligence issues

### DIFF
--- a/_layouts/coe-ai.html
+++ b/_layouts/coe-ai.html
@@ -1,0 +1,67 @@
+---
+layout: default
+---
+
+<section class="usa-grid usa-section">
+    <h1>{{ page.title }}</h1>
+    <div class="usa-width-two-thirds">
+        <p class="intro">{{ page.tagline }}</p>
+
+        <div class="page-nav">
+            <a href="#service offerings">Service Offerings</a> 
+              | {% if page.service-catalog %}
+            <a href="#service catalog">Service Catalog</a> 
+              {% endif %}
+              {% for item in page.page-nav.children %}
+            <a href="{{ site.baseurl }}/work/{{ item.url-fragment }}">Our Work at {{ item.agency }}</a> {% if forloop.last == false %} | {% endif %}{% endfor %}
+        </div>
+
+      <p>{{ page.intro }}</p>
+
+      <h2 id="service-offerings">Service Offerings</h2>
+      <ul>
+      {% for offering in page.service-offerings %}
+        <li>{{ offering }}</li>
+      {% endfor %}
+      </ul>
+
+      {% if page.service-catalog %}
+        <h2 id="service-catalog">Service Catalog</h2>
+        {% for child in page.service-catalog.children %}
+          {% if child.description %}
+            <p>{{ child.description }}</p>
+          {% endif %}
+          {% if child.list %}
+            <ul>
+              {% for item in child.list %}
+                <li>{{ item }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+
+    </div> <!-- /.usa-width-two-thirds -->
+    <div class="usa-width-one-third sticky sidebar">
+        <div class="sidebar-box {{ page.sidebar-graphic-class }}">
+            <div class="centers-graphic"></div>
+            <div class="sidebar-box-content">
+                <h4 class="first">Explore {{ page.title }} CoE</h4>
+                {% for pdf in page.pdfs %}
+                  <div style="min-height: 3rem;"><a href="{{site.baseurl}}{{ pdf.link }}" target="_blank" class="pdf">{{ pdf.title }} <img class="icon" src="{{site.baseurl}}/images/icon-pdf.png" alt="View the PDF"></a></div>
+                {% endfor %}
+            </div>
+        </div>
+        {% if page.sidebar-extra-content %}
+        {% for sidebar-box in page.sidebar-extra-content.children %}
+        <div class="sidebar-box {{ sidebar-box.img-class }}">
+            <div class="sidebar-box-content">
+                <p>{{ sidebar-box.text }}</p>
+                <a href="{{site.baseurl}}{{ sidebar-box.button-link }}" class="usa-button usa-button-secondary">{{ sidebar-box.button-text }}</a>
+            </div> <!-- /.sidebar-box-content -->
+        </div> <!-- /.sidebar-box -->
+        {% endfor %}
+        {% endif %}
+    </div> <!-- /.usa-width-one-third -->
+</section> <!-- /.usa-grid -->
+

--- a/coe/artificial-intelligence.html
+++ b/coe/artificial-intelligence.html
@@ -1,5 +1,5 @@
 ---
-layout: coe
+layout: coe-ai
 title: Artificial Intelligence
 tagline: Accelerates adoption of Artificial Intelligence to discover insights at machine speed.
 intro: "The Artificial Intelligence (AI) CoE enables agencies to develop AI solutions to meet unique business challenges by 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@ permalink: /
 layout: default
 title: Centers of Excellence Home
 cards:
+  - title: Artifical Intelligence
+    description: Accelerates adoption of Artificial Intelligence to discover insights at machine speed.
+    classname: coe-ai-link
+    url: /coe/artificial-intelligence.html
   - title: Cloud Adoption
     description: Analyzes current systems and applications to provide recommendations for planning cloud migration.
     classname: coe-ca-link
@@ -19,10 +23,7 @@ cards:
     description: Helps make more efficient use of data management, analysis, and reporting capabilities.
     classname: coe-da-link
     url: /coe/data-analytics.html
-  - title: Infrastructure Optimization
-    description: Assists in optimizing data centers and reducing infrastructure costs.
-    classname: coe-io-link
-    url: /coe/infrastructure-optimization.html
+
 quotes:
   - text: This is a significant step forward in the government’s commitment to improve citizens’ lives.
     author: Chris Liddell, White House Deputy Chief of Staff


### PR DESCRIPTION
Display AI  as center on homepage; Remove "Latest Updates" from AI page

Changes proposed in this pull request (see screenshots below):
- Homepage: 1) Swapped AI for IO; 2) Relocated AI to be first in line-up (alphabetically); 3) When AI card is clicked, it leads to the AI page 
- AI page: Removed "Latest updates" anchor and feeds

**Homepage**
![Screen Shot 2019-11-04 at 4 44 26 PM](https://user-images.githubusercontent.com/6327082/68168116-4bb0cd00-ff2d-11e9-9b9d-835e66e30eed.png)

**AI page**
![Screenshot_2019-11-04 GSA - IT Modernization Centers of Excellence](https://user-images.githubusercontent.com/6327082/68168121-523f4480-ff2d-11e9-8f04-0c44cb7c038d.png)


