### PR TITLE
Changed link path for "Centers of Excellence"

### DIFF
--- a/_includes/initiative.html
+++ b/_includes/initiative.html
@@ -1,7 +1,7 @@
 {% if include.initiative == "Customer Experience" %}
     <a href="{{site.baseurl}}/coe/customer-experience.html" class="article-coe-link">CUSTOMER EXPERIENCE</a>
 {% elsif include.initiative == "Centers of Excellence" %}
-    <a href="{{site.baseurl}}/coe/centers-of-excellence.html" class="article-coe-link">CENTERS OF EXCELLENCE</a>
+    <a href="{{site.baseurl}}/about/approach-team-structure.html#our-approach" class="article-coe-link">CENTERS OF EXCELLENCE</a>
 {% elsif include.initiative == "Artificial Intelligence" %}
     <a href="{{site.baseurl}}/coe/artificial-intelligence.html" class="article-coe-link">ARTIFICIAL INTELLIGENCE</a>
 {% elsif include.initiative == "Cloud Adoption" %}


### PR DESCRIPTION
Changed the path for CoE link in CoE site > News > Recent Updates > "centers of excellence" from outdated coe page to the "our approach" page.

Changes proposed in this pull request:
-
-
-

[:sunglasses: PREVIEW](/https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/BRANCH_NAME/)
