### PR TITLE
Relinked Twitter and LinkedIn links to open new tab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -210,8 +210,8 @@
                     <ul id="extended-nav-section-five" class="usa-nav-submenu">
                         <li><a href="{{site.baseurl}}/connect/contact-us.html">Contact Us</a></li>
                         <li><a href="{{site.baseurl}}/connect/contact-us.html#joinus">Join Us</a></li>
-                        <li><a href="https://twitter.com/GSACoE">Find Us on Twitter</a></li>
-                        <li><a href="https://www.linkedin.com/company/gsa/">Find Us on LinkedIn</a></li>
+                        <li><a target="_blank" href="https://twitter.com/GSACoE">Find Us on Twitter</a></li>
+                        <li><a target="_blank" href="https://www.linkedin.com/company/gsa/">Find Us on LinkedIn</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Changes proposed in this pull request:
- No visible changes to the site
- Links for Twitter and LinkedIn under Connect drop-down will now lead to new tab.
-

[:sunglasses: PREVIEW](/https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/BRANCH_NAME/)
