### PR TITLE
Filtered Centers Blogs from Recent Updates Page

### DIFF
--- a/press/updates.md
+++ b/press/updates.md
@@ -9,7 +9,9 @@ Every month, our team posts updates on our work, best practices or progress. Ple
 {: .intro}
 
 {% for post in site.posts %}
-    {% include article-head.html post=post show_initiative=true %}
+     {% if post.initiative != "Artificial Intelligence" and post.initiative != "Cloud Adaption" and post.initiative != "Contact Center" and post.initiative != "Customer Experience" and post.initiative != "Data and Analytics" and post.initiative != "Infrastructure Optimization" %}
+        {% include article-head.html post=post show_initiative=true %}
+     {% endif %}
 {% endfor %}
 
 <button onclick="btt()" id="btt"></button>


### PR DESCRIPTION
Changes proposed in this pull request:
- Added conditional logic to press/updates.md to filter out blog posts that are correlated to a Center of Excellence
- By filtering, the blogs will only appear in the individual centers' pages and prevent duplication of blogs
- This was requested by Star Vanamali through Danielle Gallant. 

[:sunglasses: PREVIEW](https://federalist-e3c31739-2261-4fa1-9eb6-48bf3db55ad6.app.cloud.gov/preview/gsa/centers-of-excellence/micah-kim-updates-filter/)
