### PR TITLE
Added Updates Component to Communities

### DIFF
--- a/communities/ai-blogs.md
+++ b/communities/ai-blogs.md
@@ -1,0 +1,15 @@
+---
+layout: with-grid
+title: Updates
+---
+
+# AI Community Updates
+
+    {% assign filtered_posts = site.posts | where: 'initiative', "AI" %}
+    {% for post in filtered_posts%}
+    {% include article-head.html show_post_excerpt = true %}
+    {% endfor %}
+
+<button onclick="btt()" id="btt"></button>
+
+For all press inquiries, please contact [press@gsa.gov](mailto:press@gsa.gov)

--- a/communities/ai.html
+++ b/communities/ai.html
@@ -106,6 +106,18 @@ testimonial-citation: Maria Patterson, Presidential Innovation Fellow, Departmen
 		
 	<a href="mailto:AI-subscribe-request@listserv.gsa.gov" class="usa-button">Join by Email</a>
 	
+	<h2 id="coe-updates">Latest Updates</h2>
+      {% assign filtered_posts = site.posts | where: 'initiative', "AI" %}
+	  {% assign i = 0 %}
+      {% for post in filtered_posts limit:3%}
+	    {% assign i = i | plus: 1 %}
+		{% include article-head.html show_post_excerpt = true %}
+      {% endfor %}
+	  {% if i == 3 %}
+		<a href="{{site.baseurl}}/communities/ai-blogs" class="usa-button">See All</a>
+	  {% endif %}
+
+	
     </div> <!-- /.usa-width-two-thirds -->
    
 	

--- a/communities/cc-blogs.md
+++ b/communities/cc-blogs.md
@@ -1,0 +1,15 @@
+---
+layout: with-grid
+title: Updates
+---
+
+# Contact Center Community Updates
+
+    {% assign filtered_posts = site.posts | where: 'initiative', "CC" %}
+    {% for post in filtered_posts%}
+    {% include article-head.html show_post_excerpt = true %}
+    {% endfor %}
+
+<button onclick="btt()" id="btt"></button>
+
+For all press inquiries, please contact [press@gsa.gov](mailto:press@gsa.gov)

--- a/communities/contact-center.html
+++ b/communities/contact-center.html
@@ -94,6 +94,17 @@ testimonial-citation: George Smith, Senior Executive Analyst, NASA
 		<p><strong>Note:</strong> Federal, state, local, and tribal government employees only are eligible to join.</p>
 
 	<a href="mailto:G3C-subscribe-request@listserv.gsa.gov" class="usa-button">Join by Email</a>
+
+	<h2 id="coe-updates">Latest Updates</h2>
+      {% assign filtered_posts = site.posts | where: 'initiative', "CC" %}
+	  {% assign i = 0 %}
+      {% for post in filtered_posts limit:3%}
+	    {% assign i = i | plus: 1 %}
+		{% include article-head.html show_post_excerpt = true %}
+      {% endfor %}
+	  {% if i == 3 %}
+		<a href="{{site.baseurl}}/communities/cc-blogs" class="usa-button">See All</a>
+	  {% endif %}
 	
     </div> <!-- /.usa-width-two-thirds -->
    

--- a/communities/ia-blogs.md
+++ b/communities/ia-blogs.md
@@ -1,0 +1,15 @@
+---
+layout: with-grid
+title: Updates
+---
+
+# Innovation Adoption Community Updates
+
+    {% assign filtered_posts = site.posts | where: 'initiative', "IA" %}
+    {% for post in filtered_posts%}
+    {% include article-head.html show_post_excerpt = true %}
+    {% endfor %}
+
+<button onclick="btt()" id="btt"></button>
+
+For all press inquiries, please contact [press@gsa.gov](mailto:press@gsa.gov)

--- a/communities/innovation-adoption.html
+++ b/communities/innovation-adoption.html
@@ -107,6 +107,19 @@ testimonial-citation: Jillian Brooks, Deputy, Innovation Support Services, US Na
 	<p><strong>Note:</strong> Federal government employees only are eligible to join. </p>
 	
 	<a href="mailto:INNOVATION-ADOPTION-subscribe-request@listserv.gsa.gov" class="usa-button">Join by Email</a>
+
+	<h2 id="coe-updates">Latest Updates</h2>
+      {% assign filtered_posts = site.posts | where: 'initiative', "IA" %}
+	  {% assign i = 0 %}
+      {% for post in filtered_posts limit:3%}
+	    {% assign i = i | plus: 1 %}
+		{% include article-head.html show_post_excerpt = true %}
+      {% endfor %}
+	  {% if i == 3 %}
+		<a href="{{site.baseurl}}/communities/ia-blogs" class="usa-button">See All</a>
+	  {% endif %}
+
+
 	
     </div> <!-- /.usa-width-two-thirds -->
    


### PR DESCRIPTION
Changes proposed in this pull request:
- Added Latest Updates component to bottom of each Community page
- Blogs pertaining to Communities with initiative AI, IA, and CC will automatically be linked to these updates postings
- Blogs with these initiatives will not be included in the Recent Updates page

[:sunglasses: PREVIEW](/https://federalist-proxy.app.cloud.gov/preview/gsa/centers-of-excellence/BRANCH_NAME/)
